### PR TITLE
update yaxpeax-arch to 0.2.4 and fix corresponding API changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-yaxpeax-arch = { version = "0.0.4", default-features = false, features = [] }
+yaxpeax-arch = { version = "0.2.4", default-features = false, features = [] }
 take_mut = "0.2.2"

--- a/src/display.rs
+++ b/src/display.rs
@@ -4,11 +4,8 @@ use super::{DecodeError, Instruction, Opcode, Operand};
 
 impl fmt::Display for DecodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            DecodeError::ExhaustedInput => write!(f, "exhausted input"),
-            DecodeError::InvalidOpcode => write!(f, "invalid opcode"),
-            DecodeError::InvalidOperand => write!(f, "invalid operand"),
-        }
+        use yaxpeax_arch::DecodeError;
+        f.write_str(self.description())
     }
 }
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,19 +1,19 @@
-use yaxpeax_arch::{Arch, Decoder};
 use yaxpeax_6502::{Opcode, Operand, N6502};
+use yaxpeax_arch::{Arch, Decoder, U8Reader};
 
 #[test]
 fn test_decode() {
     let decoder = <N6502 as Arch>::Decoder::default();
 
-    let data = [0xea];
-    let instr = decoder.decode(data.iter().cloned()).unwrap();
+    let data = &[0xea];
+    let instr = decoder.decode(&mut U8Reader::new(data)).unwrap();
     assert!(instr.opcode == Opcode::NOP);
 
-    let data = [0x00];
-    let instr = decoder.decode(data.iter().cloned()).unwrap();
+    let data = &[0x00];
+    let instr = decoder.decode(&mut U8Reader::new(data)).unwrap();
     assert!(instr.opcode == Opcode::BRK);
 
-    let data = [0xa2, 0xff];
-    let instr = decoder.decode(data.iter().cloned()).unwrap();
+    let data = &[0xa2, 0xff];
+    let instr = decoder.decode(&mut U8Reader::new(data)).unwrap();
     assert!(instr.opcode == Opcode::LDX);
 }


### PR DESCRIPTION
this is a relatively straightforward change and keeps yaxpeax-6502 compatible with the other decoders.

i didn't bump this crate's version but i figure now that `yaxpeax-arch` is >=0.1.0, it's safe to start versioning decoders at >=0.1.x as well. i'll leave that to your discretion when publishing a new version of the crate though!