### PR TITLE
Use StandardDecodeError as DecodeError

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -1,13 +1,6 @@
 use std::fmt::{self, Write};
 
-use super::{DecodeError, Instruction, Opcode, Operand};
-
-impl fmt::Display for DecodeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use yaxpeax_arch::DecodeError;
-        f.write_str(self.description())
-    }
-}
+use super::{Instruction, Opcode, Operand};
 
 impl fmt::Display for Instruction {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,37 +157,7 @@ impl Operand {
     }
 }
 
-#[derive(Debug, PartialEq)]
-pub enum DecodeError {
-    ExhaustedInput,
-    InvalidOpcode,
-    InvalidOperand,
-}
-
-impl yaxpeax_arch::DecodeError for DecodeError {
-    fn data_exhausted(&self) -> bool {
-        self == &DecodeError::ExhaustedInput
-    }
-    fn bad_opcode(&self) -> bool {
-        self == &DecodeError::InvalidOpcode
-    }
-    fn bad_operand(&self) -> bool {
-        self == &DecodeError::InvalidOperand
-    }
-    fn description(&self) -> &'static str {
-        match self {
-            DecodeError::ExhaustedInput => "exhausted input",
-            DecodeError::InvalidOpcode => "invalid opcode",
-            DecodeError::InvalidOperand => "invalid operand",
-        }
-    }
-}
-
-impl From<yaxpeax_arch::ReadError> for DecodeError {
-    fn from(_e: yaxpeax_arch::ReadError) -> DecodeError {
-        DecodeError::ExhaustedInput
-    }
-}
+pub type DecodeError = yaxpeax_arch::StandardDecodeError;
 
 #[derive(Debug)]
 pub struct InstDecoder;


### PR DESCRIPTION
I noticed that the DecodeError was basically the same thing as `yaxpeax_arch::StandardDecodeError`. This also fixes something where if the `std` feature of `yaxpeax-arch` is on this crate doesn't compile.
