### PR TITLE
Remove unnecessary take_mut dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,3 @@ std = ["yaxpeax-arch/std"]
 
 [dependencies]
 yaxpeax-arch = { version = "0.2.4", default-features = false, features = [] }
-take_mut = "0.2.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 #[cfg(feature = "std")]
 extern crate std;
 
-use take_mut;
 use yaxpeax_arch::{AddressDiff, Arch, Decoder, LengthedInstruction, Reader};
 
 mod display;
@@ -361,7 +360,7 @@ impl Decoder<N6502> for InstDecoder {
     ) -> Result<(), <N6502 as Arch>::DecodeError> {
         let opcode = words.next()?;
 
-        let (op_type, mut operand) = self.op_type(opcode).map_err(|e| {
+        let (op_type, operand) = self.op_type(opcode).map_err(|e| {
             inst.opcode = Opcode::Invalid(opcode);
             e
         })?;
@@ -385,7 +384,7 @@ impl Decoder<N6502> for InstDecoder {
             }
         }
 
-        take_mut::take(&mut operand, |op| match op {
+        let operand = match operand {
             Operand::Accumulator => Operand::Accumulator,
             Operand::Implied => Operand::Implied,
 
@@ -401,7 +400,7 @@ impl Decoder<N6502> for InstDecoder {
             Operand::AbsoluteX(_) => Operand::AbsoluteX(op_word),
             Operand::AbsoluteY(_) => Operand::AbsoluteY(op_word),
             Operand::Indirect(_) => Operand::Indirect(op_word),
-        });
+        };
 
         inst.opcode = op_type;
         inst.operand = operand;


### PR DESCRIPTION
When a value is in a local variable, something `take_mut` is unnecessary - you can just directly assign to it and Rust knows that it can't be read if there's a panic, because it's just in this call frame. And, assigning to it isn't even necessary in this case; you can just shadow the variable.

Related to #2 