### PR TITLE
implement an encode method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,3 +408,273 @@ impl Decoder<N6502> for InstDecoder {
         Ok(())
     }
 }
+
+impl Instruction {
+    pub fn decode(&self) -> Vec<u8> {
+        match (self.opcode, self.operand) {
+            (Opcode::BRK, Operand::Implied) => vec![0x00],
+            (Opcode::ORA, Operand::XIndexedIndirect(val)) => vec![0x01, val],
+            (Opcode::ORA, Operand::ZeroPage(val)) => vec![0x05, val],
+            (Opcode::ASL, Operand::ZeroPage(val)) => vec![0x06, val],
+            (Opcode::PHP, Operand::Implied) => vec![0x08],
+            (Opcode::ORA, Operand::Immediate(val)) => vec![0x09, val],
+            (Opcode::ASL, Operand::Accumulator) => vec![0x0a],
+            (Opcode::ORA, Operand::Absolute(addr)) => {
+                vec![0x0d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::ASL, Operand::Absolute(addr)) => {
+                vec![0x0e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+
+            (Opcode::BPL, Operand::Relative(val)) => vec![0x10, val],
+            (Opcode::ORA, Operand::IndirectYIndexed(val)) => vec![0x11, val],
+            (Opcode::ORA, Operand::ZeroPageX(val)) => vec![0x15, val],
+            (Opcode::ASL, Operand::ZeroPageX(val)) => vec![0x16, val],
+            (Opcode::CLC, Operand::Implied) => vec![0x18],
+            (Opcode::ORA, Operand::AbsoluteY(addr)) => {
+                vec![0x19, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::ORA, Operand::AbsoluteX(addr)) => {
+                vec![0x1d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::ASL, Operand::AbsoluteX(addr)) => {
+                vec![0x1e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+
+            (Opcode::JSR, Operand::Absolute(addr)) => {
+                vec![0x20, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::AND, Operand::XIndexedIndirect(val)) => vec![0x21, val],
+            (Opcode::BIT, Operand::ZeroPage(val)) => vec![0x24, val],
+            (Opcode::AND, Operand::ZeroPage(val)) => vec![0x25, val],
+            (Opcode::ROL, Operand::ZeroPage(val)) => vec![0x26, val],
+            (Opcode::PLP, Operand::Implied) => vec![0x28],
+            (Opcode::AND, Operand::Immediate(val)) => vec![0x29, val],
+            (Opcode::ROL, Operand::Accumulator) => vec![0x2a],
+            (Opcode::BIT, Operand::Absolute(addr)) => {
+                vec![0x2c, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::AND, Operand::Absolute(addr)) => {
+                vec![0x2d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+
+            (Opcode::ROL, Operand::Absolute(addr)) => {
+                vec![0x2e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::BMI, Operand::Relative(val)) => vec![0x30, val],
+            (Opcode::AND, Operand::IndirectYIndexed(val)) => vec![0x31, val],
+            (Opcode::AND, Operand::ZeroPageX(val)) => vec![0x35, val],
+            (Opcode::ROL, Operand::ZeroPageX(val)) => vec![0x36, val],
+            (Opcode::SEC, Operand::Implied) => vec![0x38],
+            (Opcode::AND, Operand::AbsoluteY(addr)) => {
+                vec![0x39, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::AND, Operand::AbsoluteX(addr)) => {
+                vec![0x3d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::ROL, Operand::AbsoluteX(addr)) => {
+                vec![0x3e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+
+            (Opcode::RTI, Operand::Implied) => vec![0x40],
+            (Opcode::EOR, Operand::XIndexedIndirect(val)) => vec![0x41, val],
+            (Opcode::EOR, Operand::ZeroPage(val)) => vec![0x45, val],
+            (Opcode::LSR, Operand::ZeroPage(val)) => vec![0x46, val],
+            (Opcode::PHA, Operand::Implied) => vec![0x48],
+            (Opcode::EOR, Operand::Immediate(val)) => vec![0x49, val],
+            (Opcode::LSR, Operand::Accumulator) => vec![0x4a],
+            (Opcode::JMP, Operand::Absolute(addr)) => {
+                vec![0x4c, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::EOR, Operand::Absolute(addr)) => {
+                vec![0x4d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::LSR, Operand::Absolute(addr)) => {
+                vec![0x4e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+
+            (Opcode::BVC, Operand::Relative(val)) => vec![0x50, val],
+            (Opcode::EOR, Operand::IndirectYIndexed(val)) => vec![0x51, val],
+            (Opcode::EOR, Operand::ZeroPageX(val)) => vec![0x55, val],
+            (Opcode::LSR, Operand::ZeroPageX(val)) => vec![0x56, val],
+            (Opcode::CLI, Operand::Implied) => vec![0x58],
+            (Opcode::EOR, Operand::AbsoluteY(addr)) => {
+                vec![0x59, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::EOR, Operand::AbsoluteX(addr)) => {
+                vec![0x5d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::LSR, Operand::AbsoluteX(addr)) => {
+                vec![0x5e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+
+            (Opcode::RTS, Operand::Implied) => vec![0x60],
+            (Opcode::ADC, Operand::XIndexedIndirect(val)) => vec![0x61, val],
+            (Opcode::ADC, Operand::ZeroPage(val)) => vec![0x65, val],
+            (Opcode::ROR, Operand::ZeroPage(val)) => vec![0x66, val],
+            (Opcode::PLA, Operand::Implied) => vec![0x68],
+            (Opcode::ADC, Operand::Immediate(val)) => vec![0x69, val],
+            (Opcode::ROR, Operand::Accumulator) => vec![0x6a],
+            (Opcode::JMP, Operand::Indirect(addr)) => {
+                vec![0x6c, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::ADC, Operand::Absolute(addr)) => {
+                vec![0x6d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::ROR, Operand::Absolute(addr)) => {
+                vec![0x6e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::BVS, Operand::Relative(val)) => vec![0x70, val],
+            (Opcode::ADC, Operand::IndirectYIndexed(val)) => vec![0x71, val],
+            (Opcode::ADC, Operand::ZeroPageX(val)) => vec![0x75, val],
+            (Opcode::ROR, Operand::ZeroPageX(val)) => vec![0x76, val],
+            (Opcode::SEI, Operand::Implied) => vec![0x78],
+            (Opcode::ADC, Operand::AbsoluteY(addr)) => {
+                vec![0x79, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::ADC, Operand::AbsoluteX(addr)) => {
+                vec![0x7d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::ROR, Operand::AbsoluteX(addr)) => {
+                vec![0x7e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+
+            (Opcode::STA, Operand::XIndexedIndirect(val)) => vec![0x81, val],
+            (Opcode::STY, Operand::ZeroPage(val)) => vec![0x84, val],
+            (Opcode::STA, Operand::ZeroPage(val)) => vec![0x85, val],
+            (Opcode::STX, Operand::ZeroPage(val)) => vec![0x86, val],
+            (Opcode::DEY, Operand::Implied) => vec![0x88],
+            (Opcode::TXA, Operand::Implied) => vec![0x8a],
+            (Opcode::STY, Operand::Absolute(addr)) => {
+                vec![0x8c, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+
+            (Opcode::STA, Operand::Absolute(addr)) => {
+                vec![0x8d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::STX, Operand::Absolute(addr)) => {
+                vec![0x8e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+
+            (Opcode::BCC, Operand::Relative(val)) => vec![0x90, val],
+            (Opcode::STA, Operand::IndirectYIndexed(val)) => vec![0x91, val],
+            (Opcode::STY, Operand::ZeroPageX(val)) => vec![0x94, val],
+            (Opcode::STA, Operand::ZeroPageX(val)) => vec![0x95, val],
+            (Opcode::STX, Operand::ZeroPageY(val)) => vec![0x96, val],
+            (Opcode::TYA, Operand::Implied) => vec![0x98],
+            (Opcode::STA, Operand::AbsoluteY(addr)) => {
+                vec![0x99, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::TXS, Operand::Implied) => vec![0x9a],
+            (Opcode::STA, Operand::AbsoluteX(addr)) => {
+                vec![0x9d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+
+            (Opcode::LDY, Operand::Immediate(val)) => vec![0xa0, val],
+            (Opcode::LDA, Operand::XIndexedIndirect(val)) => vec![0xa1, val],
+            (Opcode::LDX, Operand::Immediate(val)) => vec![0xa2, val],
+            (Opcode::LDY, Operand::ZeroPage(val)) => vec![0xa4, val],
+            (Opcode::LDA, Operand::ZeroPage(val)) => vec![0xa5, val],
+            (Opcode::LDX, Operand::ZeroPage(val)) => vec![0xa6, val],
+            (Opcode::TAY, Operand::Implied) => vec![0xa8],
+            (Opcode::LDA, Operand::Immediate(val)) => vec![0xa9, val],
+            (Opcode::TAX, Operand::Implied) => vec![0xaa],
+            (Opcode::LDY, Operand::Absolute(addr)) => {
+                vec![0xac, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::LDA, Operand::Absolute(addr)) => {
+                vec![0xad, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::LDX, Operand::Absolute(addr)) => {
+                vec![0xae, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+
+            (Opcode::BCS, Operand::Relative(val)) => vec![0xb0, val],
+            (Opcode::LDA, Operand::IndirectYIndexed(val)) => vec![0xb1, val],
+            (Opcode::LDY, Operand::ZeroPageX(val)) => vec![0xb4, val],
+            (Opcode::LDA, Operand::ZeroPageX(val)) => vec![0xb5, val],
+            (Opcode::LDX, Operand::ZeroPageY(val)) => vec![0xb6, val],
+            (Opcode::CLV, Operand::Implied) => vec![0xb8],
+            (Opcode::LDA, Operand::AbsoluteY(addr)) => {
+                vec![0xb9, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::TSX, Operand::Implied) => vec![0xba],
+            (Opcode::LDY, Operand::AbsoluteX(addr)) => {
+                vec![0xbc, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::LDA, Operand::AbsoluteX(addr)) => {
+                vec![0xbd, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::LDX, Operand::AbsoluteY(addr)) => {
+                vec![0xbe, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+
+            (Opcode::CPY, Operand::Immediate(val)) => vec![0xc0, val],
+            (Opcode::CMP, Operand::XIndexedIndirect(val)) => vec![0xc1, val],
+            (Opcode::CPY, Operand::ZeroPage(val)) => vec![0xc4, val],
+            (Opcode::CMP, Operand::ZeroPage(val)) => vec![0xc5, val],
+            (Opcode::DEC, Operand::ZeroPage(val)) => vec![0xc6, val],
+            (Opcode::INY, Operand::Implied) => vec![0xc8],
+            (Opcode::CMP, Operand::Immediate(val)) => vec![0xc9, val],
+            (Opcode::DEX, Operand::Implied) => vec![0xca],
+            (Opcode::CPY, Operand::Absolute(addr)) => {
+                vec![0xcc, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::CMP, Operand::Absolute(addr)) => {
+                vec![0xcd, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::DEC, Operand::Absolute(addr)) => {
+                vec![0xce, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+
+            (Opcode::BNE, Operand::Relative(val)) => vec![0xd0, val],
+            (Opcode::CMP, Operand::IndirectYIndexed(val)) => vec![0xd1, val],
+            (Opcode::CMP, Operand::ZeroPageX(val)) => vec![0xd5, val],
+            (Opcode::DEC, Operand::ZeroPageX(val)) => vec![0xd6, val],
+            (Opcode::CLD, Operand::Implied) => vec![0xd8],
+            (Opcode::CMP, Operand::AbsoluteY(addr)) => {
+                vec![0xd9, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::CMP, Operand::AbsoluteX(addr)) => {
+                vec![0xdd, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::DEC, Operand::AbsoluteX(addr)) => {
+                vec![0xde, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+
+            (Opcode::CPX, Operand::Immediate(val)) => vec![0xe0, val],
+            (Opcode::SBC, Operand::XIndexedIndirect(addr)) => vec![0xe1, addr],
+            (Opcode::CPX, Operand::ZeroPage(val)) => vec![0xe4, val],
+            (Opcode::SBC, Operand::ZeroPage(val)) => vec![0xe5, val],
+            (Opcode::INC, Operand::ZeroPage(val)) => vec![0xe6, val],
+            (Opcode::INX, Operand::Implied) => vec![0xe8],
+            (Opcode::SBC, Operand::Immediate(val)) => vec![0xe9, val],
+            (Opcode::NOP, Operand::Implied) => vec![0xea],
+            (Opcode::CPX, Operand::Absolute(addr)) => {
+                vec![0xec, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::SBC, Operand::Absolute(addr)) => {
+                vec![0xed, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::INC, Operand::Absolute(addr)) => {
+                vec![0xee, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+
+            (Opcode::BEQ, Operand::Relative(val)) => vec![0xf0, val],
+            (Opcode::SBC, Operand::IndirectYIndexed(val)) => vec![0xf1, val],
+            (Opcode::SBC, Operand::ZeroPageX(val)) => vec![0xf5, val],
+            (Opcode::INC, Operand::ZeroPageX(val)) => vec![0xf6, val],
+            (Opcode::SED, Operand::Implied) => vec![0xf8],
+            (Opcode::SBC, Operand::AbsoluteY(addr)) => {
+                vec![0xf9, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::SBC, Operand::AbsoluteX(addr)) => {
+                vec![0xfd, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (Opcode::INC, Operand::AbsoluteX(addr)) => {
+                vec![0xfe, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+            }
+            (_, _) => panic!(),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,9 @@ impl Operand {
 }
 
 pub type DecodeError = yaxpeax_arch::StandardDecodeError;
+pub enum EncodeError {
+    EncodeError
+}
 
 #[derive(Debug)]
 pub struct InstDecoder;
@@ -456,269 +459,269 @@ impl Iterator for Bytes {
 }
 
 impl Instruction {
-    pub fn decode(&self) -> Bytes {
+    pub fn decode(&self) -> Result<Bytes, EncodeError> {
         match (self.opcode, self.operand) {
-            (Opcode::BRK, Operand::Implied) => Bytes::one(0x00),
-            (Opcode::ORA, Operand::XIndexedIndirect(val)) => Bytes::two(0x01, val),
-            (Opcode::ORA, Operand::ZeroPage(val)) => Bytes::two(0x05, val),
-            (Opcode::ASL, Operand::ZeroPage(val)) => Bytes::two(0x06, val),
-            (Opcode::PHP, Operand::Implied) => Bytes::one(0x08),
-            (Opcode::ORA, Operand::Immediate(val)) => Bytes::two(0x09, val),
-            (Opcode::ASL, Operand::Accumulator) => Bytes::one(0x0a),
+            (Opcode::BRK, Operand::Implied) => Ok(Bytes::one(0x00)),
+            (Opcode::ORA, Operand::XIndexedIndirect(val)) => Ok(Bytes::two(0x01, val)),
+            (Opcode::ORA, Operand::ZeroPage(val)) => Ok(Bytes::two(0x05, val)),
+            (Opcode::ASL, Operand::ZeroPage(val)) => Ok(Bytes::two(0x06, val)),
+            (Opcode::PHP, Operand::Implied) => Ok(Bytes::one(0x08)),
+            (Opcode::ORA, Operand::Immediate(val)) => Ok(Bytes::two(0x09, val)),
+            (Opcode::ASL, Operand::Accumulator) => Ok(Bytes::one(0x0a)),
             (Opcode::ORA, Operand::Absolute(addr)) => {
-                Bytes::three(0x0d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x0d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::ASL, Operand::Absolute(addr)) => {
-                Bytes::three(0x0e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x0e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
 
-            (Opcode::BPL, Operand::Relative(val)) => Bytes::two(0x10, val),
-            (Opcode::ORA, Operand::IndirectYIndexed(val)) => Bytes::two(0x11, val),
-            (Opcode::ORA, Operand::ZeroPageX(val)) => Bytes::two(0x15, val),
-            (Opcode::ASL, Operand::ZeroPageX(val)) => Bytes::two(0x16, val),
-            (Opcode::CLC, Operand::Implied) => Bytes::one(0x18),
+            (Opcode::BPL, Operand::Relative(val)) => Ok(Bytes::two(0x10, val)),
+            (Opcode::ORA, Operand::IndirectYIndexed(val)) => Ok(Bytes::two(0x11, val)),
+            (Opcode::ORA, Operand::ZeroPageX(val)) => Ok(Bytes::two(0x15, val)),
+            (Opcode::ASL, Operand::ZeroPageX(val)) => Ok(Bytes::two(0x16, val)),
+            (Opcode::CLC, Operand::Implied) => Ok(Bytes::one(0x18)),
             (Opcode::ORA, Operand::AbsoluteY(addr)) => {
-                Bytes::three(0x19, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x19, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::ORA, Operand::AbsoluteX(addr)) => {
-                Bytes::three(0x1d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x1d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::ASL, Operand::AbsoluteX(addr)) => {
-                Bytes::three(0x1e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x1e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
 
             (Opcode::JSR, Operand::Absolute(addr)) => {
-                Bytes::three(0x20, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x20, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
-            (Opcode::AND, Operand::XIndexedIndirect(val)) => Bytes::two(0x21, val),
-            (Opcode::BIT, Operand::ZeroPage(val)) => Bytes::two(0x24, val),
-            (Opcode::AND, Operand::ZeroPage(val)) => Bytes::two(0x25, val),
-            (Opcode::ROL, Operand::ZeroPage(val)) => Bytes::two(0x26, val),
-            (Opcode::PLP, Operand::Implied) => Bytes::one(0x28),
-            (Opcode::AND, Operand::Immediate(val)) => Bytes::two(0x29, val),
-            (Opcode::ROL, Operand::Accumulator) => Bytes::one(0x2a),
+            (Opcode::AND, Operand::XIndexedIndirect(val)) => Ok(Bytes::two(0x21, val)),
+            (Opcode::BIT, Operand::ZeroPage(val)) => Ok(Bytes::two(0x24, val)),
+            (Opcode::AND, Operand::ZeroPage(val)) => Ok(Bytes::two(0x25, val)),
+            (Opcode::ROL, Operand::ZeroPage(val)) => Ok(Bytes::two(0x26, val)),
+            (Opcode::PLP, Operand::Implied) => Ok(Bytes::one(0x28)),
+            (Opcode::AND, Operand::Immediate(val)) => Ok(Bytes::two(0x29, val)),
+            (Opcode::ROL, Operand::Accumulator) => Ok(Bytes::one(0x2a)),
             (Opcode::BIT, Operand::Absolute(addr)) => {
-                Bytes::three(0x2c, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x2c, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::AND, Operand::Absolute(addr)) => {
-                Bytes::three(0x2d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x2d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
 
             (Opcode::ROL, Operand::Absolute(addr)) => {
-                Bytes::three(0x2e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x2e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
-            (Opcode::BMI, Operand::Relative(val)) => Bytes::two(0x30, val),
-            (Opcode::AND, Operand::IndirectYIndexed(val)) => Bytes::two(0x31, val),
-            (Opcode::AND, Operand::ZeroPageX(val)) => Bytes::two(0x35, val),
-            (Opcode::ROL, Operand::ZeroPageX(val)) => Bytes::two(0x36, val),
-            (Opcode::SEC, Operand::Implied) => Bytes::one(0x38),
+            (Opcode::BMI, Operand::Relative(val)) => Ok(Bytes::two(0x30, val)),
+            (Opcode::AND, Operand::IndirectYIndexed(val)) => Ok(Bytes::two(0x31, val)),
+            (Opcode::AND, Operand::ZeroPageX(val)) => Ok(Bytes::two(0x35, val)),
+            (Opcode::ROL, Operand::ZeroPageX(val)) => Ok(Bytes::two(0x36, val)),
+            (Opcode::SEC, Operand::Implied) => Ok(Bytes::one(0x38)),
             (Opcode::AND, Operand::AbsoluteY(addr)) => {
-                Bytes::three(0x39, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x39, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::AND, Operand::AbsoluteX(addr)) => {
-                Bytes::three(0x3d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x3d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::ROL, Operand::AbsoluteX(addr)) => {
-                Bytes::three(0x3e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x3e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
 
-            (Opcode::RTI, Operand::Implied) => Bytes::one(0x40),
-            (Opcode::EOR, Operand::XIndexedIndirect(val)) => Bytes::two(0x41, val),
-            (Opcode::EOR, Operand::ZeroPage(val)) => Bytes::two(0x45, val),
-            (Opcode::LSR, Operand::ZeroPage(val)) => Bytes::two(0x46, val),
-            (Opcode::PHA, Operand::Implied) => Bytes::one(0x48),
-            (Opcode::EOR, Operand::Immediate(val)) => Bytes::two(0x49, val),
-            (Opcode::LSR, Operand::Accumulator) => Bytes::one(0x4a),
+            (Opcode::RTI, Operand::Implied) => Ok(Bytes::one(0x40)),
+            (Opcode::EOR, Operand::XIndexedIndirect(val)) => Ok(Bytes::two(0x41, val)),
+            (Opcode::EOR, Operand::ZeroPage(val)) => Ok(Bytes::two(0x45, val)),
+            (Opcode::LSR, Operand::ZeroPage(val)) => Ok(Bytes::two(0x46, val)),
+            (Opcode::PHA, Operand::Implied) => Ok(Bytes::one(0x48)),
+            (Opcode::EOR, Operand::Immediate(val)) => Ok(Bytes::two(0x49, val)),
+            (Opcode::LSR, Operand::Accumulator) => Ok(Bytes::one(0x4a)),
             (Opcode::JMP, Operand::Absolute(addr)) => {
-                Bytes::three(0x4c, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x4c, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::EOR, Operand::Absolute(addr)) => {
-                Bytes::three(0x4d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x4d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::LSR, Operand::Absolute(addr)) => {
-                Bytes::three(0x4e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x4e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
 
-            (Opcode::BVC, Operand::Relative(val)) => Bytes::two(0x50, val),
-            (Opcode::EOR, Operand::IndirectYIndexed(val)) => Bytes::two(0x51, val),
-            (Opcode::EOR, Operand::ZeroPageX(val)) => Bytes::two(0x55, val),
-            (Opcode::LSR, Operand::ZeroPageX(val)) => Bytes::two(0x56, val),
-            (Opcode::CLI, Operand::Implied) => Bytes::one(0x58),
+            (Opcode::BVC, Operand::Relative(val)) => Ok(Bytes::two(0x50, val)),
+            (Opcode::EOR, Operand::IndirectYIndexed(val)) => Ok(Bytes::two(0x51, val)),
+            (Opcode::EOR, Operand::ZeroPageX(val)) => Ok(Bytes::two(0x55, val)),
+            (Opcode::LSR, Operand::ZeroPageX(val)) => Ok(Bytes::two(0x56, val)),
+            (Opcode::CLI, Operand::Implied) => Ok(Bytes::one(0x58)),
             (Opcode::EOR, Operand::AbsoluteY(addr)) => {
-                Bytes::three(0x59, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x59, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::EOR, Operand::AbsoluteX(addr)) => {
-                Bytes::three(0x5d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x5d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::LSR, Operand::AbsoluteX(addr)) => {
-                Bytes::three(0x5e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x5e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
 
-            (Opcode::RTS, Operand::Implied) => Bytes::one(0x60),
-            (Opcode::ADC, Operand::XIndexedIndirect(val)) => Bytes::two(0x61, val),
-            (Opcode::ADC, Operand::ZeroPage(val)) => Bytes::two(0x65, val),
-            (Opcode::ROR, Operand::ZeroPage(val)) => Bytes::two(0x66, val),
-            (Opcode::PLA, Operand::Implied) => Bytes::one(0x68),
-            (Opcode::ADC, Operand::Immediate(val)) => Bytes::two(0x69, val),
-            (Opcode::ROR, Operand::Accumulator) => Bytes::one(0x6a),
+            (Opcode::RTS, Operand::Implied) => Ok(Bytes::one(0x60)),
+            (Opcode::ADC, Operand::XIndexedIndirect(val)) => Ok(Bytes::two(0x61, val)),
+            (Opcode::ADC, Operand::ZeroPage(val)) => Ok(Bytes::two(0x65, val)),
+            (Opcode::ROR, Operand::ZeroPage(val)) => Ok(Bytes::two(0x66, val)),
+            (Opcode::PLA, Operand::Implied) => Ok(Bytes::one(0x68)),
+            (Opcode::ADC, Operand::Immediate(val)) => Ok(Bytes::two(0x69, val)),
+            (Opcode::ROR, Operand::Accumulator) => Ok(Bytes::one(0x6a)),
             (Opcode::JMP, Operand::Indirect(addr)) => {
-                Bytes::three(0x6c, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x6c, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::ADC, Operand::Absolute(addr)) => {
-                Bytes::three(0x6d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x6d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::ROR, Operand::Absolute(addr)) => {
-                Bytes::three(0x6e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x6e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
-            (Opcode::BVS, Operand::Relative(val)) => Bytes::two(0x70, val),
-            (Opcode::ADC, Operand::IndirectYIndexed(val)) => Bytes::two(0x71, val),
-            (Opcode::ADC, Operand::ZeroPageX(val)) => Bytes::two(0x75, val),
-            (Opcode::ROR, Operand::ZeroPageX(val)) => Bytes::two(0x76, val),
-            (Opcode::SEI, Operand::Implied) => Bytes::one(0x78),
+            (Opcode::BVS, Operand::Relative(val)) => Ok(Bytes::two(0x70, val)),
+            (Opcode::ADC, Operand::IndirectYIndexed(val)) => Ok(Bytes::two(0x71, val)),
+            (Opcode::ADC, Operand::ZeroPageX(val)) => Ok(Bytes::two(0x75, val)),
+            (Opcode::ROR, Operand::ZeroPageX(val)) => Ok(Bytes::two(0x76, val)),
+            (Opcode::SEI, Operand::Implied) => Ok(Bytes::one(0x78)),
             (Opcode::ADC, Operand::AbsoluteY(addr)) => {
-                Bytes::three(0x79, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x79, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::ADC, Operand::AbsoluteX(addr)) => {
-                Bytes::three(0x7d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x7d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::ROR, Operand::AbsoluteX(addr)) => {
-                Bytes::three(0x7e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x7e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
 
-            (Opcode::STA, Operand::XIndexedIndirect(val)) => Bytes::two(0x81, val),
-            (Opcode::STY, Operand::ZeroPage(val)) => Bytes::two(0x84, val),
-            (Opcode::STA, Operand::ZeroPage(val)) => Bytes::two(0x85, val),
-            (Opcode::STX, Operand::ZeroPage(val)) => Bytes::two(0x86, val),
-            (Opcode::DEY, Operand::Implied) => Bytes::one(0x88),
-            (Opcode::TXA, Operand::Implied) => Bytes::one(0x8a),
+            (Opcode::STA, Operand::XIndexedIndirect(val)) => Ok(Bytes::two(0x81, val)),
+            (Opcode::STY, Operand::ZeroPage(val)) => Ok(Bytes::two(0x84, val)),
+            (Opcode::STA, Operand::ZeroPage(val)) => Ok(Bytes::two(0x85, val)),
+            (Opcode::STX, Operand::ZeroPage(val)) => Ok(Bytes::two(0x86, val)),
+            (Opcode::DEY, Operand::Implied) => Ok(Bytes::one(0x88)),
+            (Opcode::TXA, Operand::Implied) => Ok(Bytes::one(0x8a)),
             (Opcode::STY, Operand::Absolute(addr)) => {
-                Bytes::three(0x8c, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x8c, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
 
             (Opcode::STA, Operand::Absolute(addr)) => {
-                Bytes::three(0x8d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x8d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::STX, Operand::Absolute(addr)) => {
-                Bytes::three(0x8e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x8e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
 
-            (Opcode::BCC, Operand::Relative(val)) => Bytes::two(0x90, val),
-            (Opcode::STA, Operand::IndirectYIndexed(val)) => Bytes::two(0x91, val),
-            (Opcode::STY, Operand::ZeroPageX(val)) => Bytes::two(0x94, val),
-            (Opcode::STA, Operand::ZeroPageX(val)) => Bytes::two(0x95, val),
-            (Opcode::STX, Operand::ZeroPageY(val)) => Bytes::two(0x96, val),
-            (Opcode::TYA, Operand::Implied) => Bytes::one(0x98),
+            (Opcode::BCC, Operand::Relative(val)) => Ok(Bytes::two(0x90, val)),
+            (Opcode::STA, Operand::IndirectYIndexed(val)) => Ok(Bytes::two(0x91, val)),
+            (Opcode::STY, Operand::ZeroPageX(val)) => Ok(Bytes::two(0x94, val)),
+            (Opcode::STA, Operand::ZeroPageX(val)) => Ok(Bytes::two(0x95, val)),
+            (Opcode::STX, Operand::ZeroPageY(val)) => Ok(Bytes::two(0x96, val)),
+            (Opcode::TYA, Operand::Implied) => Ok(Bytes::one(0x98)),
             (Opcode::STA, Operand::AbsoluteY(addr)) => {
-                Bytes::three(0x99, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x99, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
-            (Opcode::TXS, Operand::Implied) => Bytes::one(0x9a),
+            (Opcode::TXS, Operand::Implied) => Ok(Bytes::one(0x9a)),
             (Opcode::STA, Operand::AbsoluteX(addr)) => {
-                Bytes::three(0x9d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0x9d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
 
-            (Opcode::LDY, Operand::Immediate(val)) => Bytes::two(0xa0, val),
-            (Opcode::LDA, Operand::XIndexedIndirect(val)) => Bytes::two(0xa1, val),
-            (Opcode::LDX, Operand::Immediate(val)) => Bytes::two(0xa2, val),
-            (Opcode::LDY, Operand::ZeroPage(val)) => Bytes::two(0xa4, val),
-            (Opcode::LDA, Operand::ZeroPage(val)) => Bytes::two(0xa5, val),
-            (Opcode::LDX, Operand::ZeroPage(val)) => Bytes::two(0xa6, val),
-            (Opcode::TAY, Operand::Implied) => Bytes::one(0xa8),
-            (Opcode::LDA, Operand::Immediate(val)) => Bytes::two(0xa9, val),
-            (Opcode::TAX, Operand::Implied) => Bytes::one(0xaa),
+            (Opcode::LDY, Operand::Immediate(val)) => Ok(Bytes::two(0xa0, val)),
+            (Opcode::LDA, Operand::XIndexedIndirect(val)) => Ok(Bytes::two(0xa1, val)),
+            (Opcode::LDX, Operand::Immediate(val)) => Ok(Bytes::two(0xa2, val)),
+            (Opcode::LDY, Operand::ZeroPage(val)) => Ok(Bytes::two(0xa4, val)),
+            (Opcode::LDA, Operand::ZeroPage(val)) => Ok(Bytes::two(0xa5, val)),
+            (Opcode::LDX, Operand::ZeroPage(val)) => Ok(Bytes::two(0xa6, val)),
+            (Opcode::TAY, Operand::Implied) => Ok(Bytes::one(0xa8)),
+            (Opcode::LDA, Operand::Immediate(val)) => Ok(Bytes::two(0xa9, val)),
+            (Opcode::TAX, Operand::Implied) => Ok(Bytes::one(0xaa)),
             (Opcode::LDY, Operand::Absolute(addr)) => {
-                Bytes::three(0xac, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0xac, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::LDA, Operand::Absolute(addr)) => {
-                Bytes::three(0xad, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0xad, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::LDX, Operand::Absolute(addr)) => {
-                Bytes::three(0xae, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0xae, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
 
-            (Opcode::BCS, Operand::Relative(val)) => Bytes::two(0xb0, val),
-            (Opcode::LDA, Operand::IndirectYIndexed(val)) => Bytes::two(0xb1, val),
-            (Opcode::LDY, Operand::ZeroPageX(val)) => Bytes::two(0xb4, val),
-            (Opcode::LDA, Operand::ZeroPageX(val)) => Bytes::two(0xb5, val),
-            (Opcode::LDX, Operand::ZeroPageY(val)) => Bytes::two(0xb6, val),
-            (Opcode::CLV, Operand::Implied) => Bytes::one(0xb8),
+            (Opcode::BCS, Operand::Relative(val)) => Ok(Bytes::two(0xb0, val)),
+            (Opcode::LDA, Operand::IndirectYIndexed(val)) => Ok(Bytes::two(0xb1, val)),
+            (Opcode::LDY, Operand::ZeroPageX(val)) => Ok(Bytes::two(0xb4, val)),
+            (Opcode::LDA, Operand::ZeroPageX(val)) => Ok(Bytes::two(0xb5, val)),
+            (Opcode::LDX, Operand::ZeroPageY(val)) => Ok(Bytes::two(0xb6, val)),
+            (Opcode::CLV, Operand::Implied) => Ok(Bytes::one(0xb8)),
             (Opcode::LDA, Operand::AbsoluteY(addr)) => {
-                Bytes::three(0xb9, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0xb9, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
-            (Opcode::TSX, Operand::Implied) => Bytes::one(0xba),
+            (Opcode::TSX, Operand::Implied) => Ok(Bytes::one(0xba)),
             (Opcode::LDY, Operand::AbsoluteX(addr)) => {
-                Bytes::three(0xbc, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0xbc, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::LDA, Operand::AbsoluteX(addr)) => {
-                Bytes::three(0xbd, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0xbd, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::LDX, Operand::AbsoluteY(addr)) => {
-                Bytes::three(0xbe, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0xbe, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
 
-            (Opcode::CPY, Operand::Immediate(val)) => Bytes::two(0xc0, val),
-            (Opcode::CMP, Operand::XIndexedIndirect(val)) => Bytes::two(0xc1, val),
-            (Opcode::CPY, Operand::ZeroPage(val)) => Bytes::two(0xc4, val),
-            (Opcode::CMP, Operand::ZeroPage(val)) => Bytes::two(0xc5, val),
-            (Opcode::DEC, Operand::ZeroPage(val)) => Bytes::two(0xc6, val),
-            (Opcode::INY, Operand::Implied) => Bytes::one(0xc8),
-            (Opcode::CMP, Operand::Immediate(val)) => Bytes::two(0xc9, val),
-            (Opcode::DEX, Operand::Implied) => Bytes::one(0xca),
+            (Opcode::CPY, Operand::Immediate(val)) => Ok(Bytes::two(0xc0, val)),
+            (Opcode::CMP, Operand::XIndexedIndirect(val)) => Ok(Bytes::two(0xc1, val)),
+            (Opcode::CPY, Operand::ZeroPage(val)) => Ok(Bytes::two(0xc4, val)),
+            (Opcode::CMP, Operand::ZeroPage(val)) => Ok(Bytes::two(0xc5, val)),
+            (Opcode::DEC, Operand::ZeroPage(val)) => Ok(Bytes::two(0xc6, val)),
+            (Opcode::INY, Operand::Implied) => Ok(Bytes::one(0xc8)),
+            (Opcode::CMP, Operand::Immediate(val)) => Ok(Bytes::two(0xc9, val)),
+            (Opcode::DEX, Operand::Implied) => Ok(Bytes::one(0xca)),
             (Opcode::CPY, Operand::Absolute(addr)) => {
-                Bytes::three(0xcc, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0xcc, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::CMP, Operand::Absolute(addr)) => {
-                Bytes::three(0xcd, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0xcd, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::DEC, Operand::Absolute(addr)) => {
-                Bytes::three(0xce, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0xce, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
 
-            (Opcode::BNE, Operand::Relative(val)) => Bytes::two(0xd0, val),
-            (Opcode::CMP, Operand::IndirectYIndexed(val)) => Bytes::two(0xd1, val),
-            (Opcode::CMP, Operand::ZeroPageX(val)) => Bytes::two(0xd5, val),
-            (Opcode::DEC, Operand::ZeroPageX(val)) => Bytes::two(0xd6, val),
-            (Opcode::CLD, Operand::Implied) => Bytes::one(0xd8),
+            (Opcode::BNE, Operand::Relative(val)) => Ok(Bytes::two(0xd0, val)),
+            (Opcode::CMP, Operand::IndirectYIndexed(val)) => Ok(Bytes::two(0xd1, val)),
+            (Opcode::CMP, Operand::ZeroPageX(val)) => Ok(Bytes::two(0xd5, val)),
+            (Opcode::DEC, Operand::ZeroPageX(val)) => Ok(Bytes::two(0xd6, val)),
+            (Opcode::CLD, Operand::Implied) => Ok(Bytes::one(0xd8)),
             (Opcode::CMP, Operand::AbsoluteY(addr)) => {
-                Bytes::three(0xd9, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0xd9, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::CMP, Operand::AbsoluteX(addr)) => {
-                Bytes::three(0xdd, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0xdd, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::DEC, Operand::AbsoluteX(addr)) => {
-                Bytes::three(0xde, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0xde, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
 
-            (Opcode::CPX, Operand::Immediate(val)) => Bytes::two(0xe0, val),
-            (Opcode::SBC, Operand::XIndexedIndirect(addr)) => Bytes::two(0xe1, addr),
-            (Opcode::CPX, Operand::ZeroPage(val)) => Bytes::two(0xe4, val),
-            (Opcode::SBC, Operand::ZeroPage(val)) => Bytes::two(0xe5, val),
-            (Opcode::INC, Operand::ZeroPage(val)) => Bytes::two(0xe6, val),
-            (Opcode::INX, Operand::Implied) => Bytes::one(0xe8),
-            (Opcode::SBC, Operand::Immediate(val)) => Bytes::two(0xe9, val),
-            (Opcode::NOP, Operand::Implied) => Bytes::one(0xea),
+            (Opcode::CPX, Operand::Immediate(val)) => Ok(Bytes::two(0xe0, val)),
+            (Opcode::SBC, Operand::XIndexedIndirect(addr)) => Ok(Bytes::two(0xe1, addr)),
+            (Opcode::CPX, Operand::ZeroPage(val)) => Ok(Bytes::two(0xe4, val)),
+            (Opcode::SBC, Operand::ZeroPage(val)) => Ok(Bytes::two(0xe5, val)),
+            (Opcode::INC, Operand::ZeroPage(val)) => Ok(Bytes::two(0xe6, val)),
+            (Opcode::INX, Operand::Implied) => Ok(Bytes::one(0xe8)),
+            (Opcode::SBC, Operand::Immediate(val)) => Ok(Bytes::two(0xe9, val)),
+            (Opcode::NOP, Operand::Implied) => Ok(Bytes::one(0xea)),
             (Opcode::CPX, Operand::Absolute(addr)) => {
-                Bytes::three(0xec, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0xec, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::SBC, Operand::Absolute(addr)) => {
-                Bytes::three(0xed, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0xed, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::INC, Operand::Absolute(addr)) => {
-                Bytes::three(0xee, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0xee, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
 
-            (Opcode::BEQ, Operand::Relative(val)) => Bytes::two(0xf0, val),
-            (Opcode::SBC, Operand::IndirectYIndexed(val)) => Bytes::two(0xf1, val),
-            (Opcode::SBC, Operand::ZeroPageX(val)) => Bytes::two(0xf5, val),
-            (Opcode::INC, Operand::ZeroPageX(val)) => Bytes::two(0xf6, val),
-            (Opcode::SED, Operand::Implied) => Bytes::one(0xf8),
+            (Opcode::BEQ, Operand::Relative(val)) => Ok(Bytes::two(0xf0, val)),
+            (Opcode::SBC, Operand::IndirectYIndexed(val)) => Ok(Bytes::two(0xf1, val)),
+            (Opcode::SBC, Operand::ZeroPageX(val)) => Ok(Bytes::two(0xf5, val)),
+            (Opcode::INC, Operand::ZeroPageX(val)) => Ok(Bytes::two(0xf6, val)),
+            (Opcode::SED, Operand::Implied) => Ok(Bytes::one(0xf8)),
             (Opcode::SBC, Operand::AbsoluteY(addr)) => {
-                Bytes::three(0xf9, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0xf9, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::SBC, Operand::AbsoluteX(addr)) => {
-                Bytes::three(0xfd, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0xfd, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (Opcode::INC, Operand::AbsoluteX(addr)) => {
-                Bytes::three(0xfe, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Ok(Bytes::three(0xfe, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
             (_, _) => panic!(),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,270 +409,316 @@ impl Decoder<N6502> for InstDecoder {
     }
 }
 
+pub struct ByteByByte {
+    b1: u8,
+    b2: u8,
+    b3: u8,
+    num: usize,
+}
+
+impl ByteByByte {
+    fn one(b1: u8) -> Self {
+        Self {
+            b1,
+            b2: 0,
+            b3: 0,
+            num: 1,
+        }
+    }
+
+    fn two(b1: u8, b2: u8) -> Self {
+        Self {
+            b1,
+            b2,
+            b3: 0,
+            num: 2,
+        }
+    }
+
+    fn three(b1: u8, b2: u8, b3: u8) -> Self {
+        Self { b1, b2, b3, num: 3 }
+    }
+}
+
+impl Iterator for ByteByByte {
+    type Item = u8;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let ret = match self.num {
+            3 => Some(self.b3),
+            2 => Some(self.b2),
+            1 => Some(self.b1),
+            _ => None,
+        };
+        self.num -= 1;
+        ret
+    }
+}
+
 impl Instruction {
-    pub fn decode(&self) -> Vec<u8> {
+    pub fn decode(&self) -> ByteByByte {
         match (self.opcode, self.operand) {
-            (Opcode::BRK, Operand::Implied) => vec![0x00],
-            (Opcode::ORA, Operand::XIndexedIndirect(val)) => vec![0x01, val],
-            (Opcode::ORA, Operand::ZeroPage(val)) => vec![0x05, val],
-            (Opcode::ASL, Operand::ZeroPage(val)) => vec![0x06, val],
-            (Opcode::PHP, Operand::Implied) => vec![0x08],
-            (Opcode::ORA, Operand::Immediate(val)) => vec![0x09, val],
-            (Opcode::ASL, Operand::Accumulator) => vec![0x0a],
+            (Opcode::BRK, Operand::Implied) => ByteByByte::one(0x00),
+            (Opcode::ORA, Operand::XIndexedIndirect(val)) => ByteByByte::two(0x01, val),
+            (Opcode::ORA, Operand::ZeroPage(val)) => ByteByByte::two(0x05, val),
+            (Opcode::ASL, Operand::ZeroPage(val)) => ByteByByte::two(0x06, val),
+            (Opcode::PHP, Operand::Implied) => ByteByByte::one(0x08),
+            (Opcode::ORA, Operand::Immediate(val)) => ByteByByte::two(0x09, val),
+            (Opcode::ASL, Operand::Accumulator) => ByteByByte::one(0x0a),
             (Opcode::ORA, Operand::Absolute(addr)) => {
-                vec![0x0d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x0d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::ASL, Operand::Absolute(addr)) => {
-                vec![0x0e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x0e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
-            (Opcode::BPL, Operand::Relative(val)) => vec![0x10, val],
-            (Opcode::ORA, Operand::IndirectYIndexed(val)) => vec![0x11, val],
-            (Opcode::ORA, Operand::ZeroPageX(val)) => vec![0x15, val],
-            (Opcode::ASL, Operand::ZeroPageX(val)) => vec![0x16, val],
-            (Opcode::CLC, Operand::Implied) => vec![0x18],
+            (Opcode::BPL, Operand::Relative(val)) => ByteByByte::two(0x10, val),
+            (Opcode::ORA, Operand::IndirectYIndexed(val)) => ByteByByte::two(0x11, val),
+            (Opcode::ORA, Operand::ZeroPageX(val)) => ByteByByte::two(0x15, val),
+            (Opcode::ASL, Operand::ZeroPageX(val)) => ByteByByte::two(0x16, val),
+            (Opcode::CLC, Operand::Implied) => ByteByByte::one(0x18),
             (Opcode::ORA, Operand::AbsoluteY(addr)) => {
-                vec![0x19, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x19, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::ORA, Operand::AbsoluteX(addr)) => {
-                vec![0x1d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x1d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::ASL, Operand::AbsoluteX(addr)) => {
-                vec![0x1e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x1e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
             (Opcode::JSR, Operand::Absolute(addr)) => {
-                vec![0x20, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x20, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
-            (Opcode::AND, Operand::XIndexedIndirect(val)) => vec![0x21, val],
-            (Opcode::BIT, Operand::ZeroPage(val)) => vec![0x24, val],
-            (Opcode::AND, Operand::ZeroPage(val)) => vec![0x25, val],
-            (Opcode::ROL, Operand::ZeroPage(val)) => vec![0x26, val],
-            (Opcode::PLP, Operand::Implied) => vec![0x28],
-            (Opcode::AND, Operand::Immediate(val)) => vec![0x29, val],
-            (Opcode::ROL, Operand::Accumulator) => vec![0x2a],
+            (Opcode::AND, Operand::XIndexedIndirect(val)) => ByteByByte::two(0x21, val),
+            (Opcode::BIT, Operand::ZeroPage(val)) => ByteByByte::two(0x24, val),
+            (Opcode::AND, Operand::ZeroPage(val)) => ByteByByte::two(0x25, val),
+            (Opcode::ROL, Operand::ZeroPage(val)) => ByteByByte::two(0x26, val),
+            (Opcode::PLP, Operand::Implied) => ByteByByte::one(0x28),
+            (Opcode::AND, Operand::Immediate(val)) => ByteByByte::two(0x29, val),
+            (Opcode::ROL, Operand::Accumulator) => ByteByByte::one(0x2a),
             (Opcode::BIT, Operand::Absolute(addr)) => {
-                vec![0x2c, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x2c, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::AND, Operand::Absolute(addr)) => {
-                vec![0x2d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x2d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
             (Opcode::ROL, Operand::Absolute(addr)) => {
-                vec![0x2e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x2e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
-            (Opcode::BMI, Operand::Relative(val)) => vec![0x30, val],
-            (Opcode::AND, Operand::IndirectYIndexed(val)) => vec![0x31, val],
-            (Opcode::AND, Operand::ZeroPageX(val)) => vec![0x35, val],
-            (Opcode::ROL, Operand::ZeroPageX(val)) => vec![0x36, val],
-            (Opcode::SEC, Operand::Implied) => vec![0x38],
+            (Opcode::BMI, Operand::Relative(val)) => ByteByByte::two(0x30, val),
+            (Opcode::AND, Operand::IndirectYIndexed(val)) => ByteByByte::two(0x31, val),
+            (Opcode::AND, Operand::ZeroPageX(val)) => ByteByByte::two(0x35, val),
+            (Opcode::ROL, Operand::ZeroPageX(val)) => ByteByByte::two(0x36, val),
+            (Opcode::SEC, Operand::Implied) => ByteByByte::one(0x38),
             (Opcode::AND, Operand::AbsoluteY(addr)) => {
-                vec![0x39, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x39, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::AND, Operand::AbsoluteX(addr)) => {
-                vec![0x3d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x3d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::ROL, Operand::AbsoluteX(addr)) => {
-                vec![0x3e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x3e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
-            (Opcode::RTI, Operand::Implied) => vec![0x40],
-            (Opcode::EOR, Operand::XIndexedIndirect(val)) => vec![0x41, val],
-            (Opcode::EOR, Operand::ZeroPage(val)) => vec![0x45, val],
-            (Opcode::LSR, Operand::ZeroPage(val)) => vec![0x46, val],
-            (Opcode::PHA, Operand::Implied) => vec![0x48],
-            (Opcode::EOR, Operand::Immediate(val)) => vec![0x49, val],
-            (Opcode::LSR, Operand::Accumulator) => vec![0x4a],
+            (Opcode::RTI, Operand::Implied) => ByteByByte::one(0x40),
+            (Opcode::EOR, Operand::XIndexedIndirect(val)) => ByteByByte::two(0x41, val),
+            (Opcode::EOR, Operand::ZeroPage(val)) => ByteByByte::two(0x45, val),
+            (Opcode::LSR, Operand::ZeroPage(val)) => ByteByByte::two(0x46, val),
+            (Opcode::PHA, Operand::Implied) => ByteByByte::one(0x48),
+            (Opcode::EOR, Operand::Immediate(val)) => ByteByByte::two(0x49, val),
+            (Opcode::LSR, Operand::Accumulator) => ByteByByte::one(0x4a),
             (Opcode::JMP, Operand::Absolute(addr)) => {
-                vec![0x4c, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x4c, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::EOR, Operand::Absolute(addr)) => {
-                vec![0x4d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x4d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::LSR, Operand::Absolute(addr)) => {
-                vec![0x4e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x4e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
-            (Opcode::BVC, Operand::Relative(val)) => vec![0x50, val],
-            (Opcode::EOR, Operand::IndirectYIndexed(val)) => vec![0x51, val],
-            (Opcode::EOR, Operand::ZeroPageX(val)) => vec![0x55, val],
-            (Opcode::LSR, Operand::ZeroPageX(val)) => vec![0x56, val],
-            (Opcode::CLI, Operand::Implied) => vec![0x58],
+            (Opcode::BVC, Operand::Relative(val)) => ByteByByte::two(0x50, val),
+            (Opcode::EOR, Operand::IndirectYIndexed(val)) => ByteByByte::two(0x51, val),
+            (Opcode::EOR, Operand::ZeroPageX(val)) => ByteByByte::two(0x55, val),
+            (Opcode::LSR, Operand::ZeroPageX(val)) => ByteByByte::two(0x56, val),
+            (Opcode::CLI, Operand::Implied) => ByteByByte::one(0x58),
             (Opcode::EOR, Operand::AbsoluteY(addr)) => {
-                vec![0x59, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x59, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::EOR, Operand::AbsoluteX(addr)) => {
-                vec![0x5d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x5d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::LSR, Operand::AbsoluteX(addr)) => {
-                vec![0x5e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x5e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
-            (Opcode::RTS, Operand::Implied) => vec![0x60],
-            (Opcode::ADC, Operand::XIndexedIndirect(val)) => vec![0x61, val],
-            (Opcode::ADC, Operand::ZeroPage(val)) => vec![0x65, val],
-            (Opcode::ROR, Operand::ZeroPage(val)) => vec![0x66, val],
-            (Opcode::PLA, Operand::Implied) => vec![0x68],
-            (Opcode::ADC, Operand::Immediate(val)) => vec![0x69, val],
-            (Opcode::ROR, Operand::Accumulator) => vec![0x6a],
+            (Opcode::RTS, Operand::Implied) => ByteByByte::one(0x60),
+            (Opcode::ADC, Operand::XIndexedIndirect(val)) => ByteByByte::two(0x61, val),
+            (Opcode::ADC, Operand::ZeroPage(val)) => ByteByByte::two(0x65, val),
+            (Opcode::ROR, Operand::ZeroPage(val)) => ByteByByte::two(0x66, val),
+            (Opcode::PLA, Operand::Implied) => ByteByByte::one(0x68),
+            (Opcode::ADC, Operand::Immediate(val)) => ByteByByte::two(0x69, val),
+            (Opcode::ROR, Operand::Accumulator) => ByteByByte::one(0x6a),
             (Opcode::JMP, Operand::Indirect(addr)) => {
-                vec![0x6c, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x6c, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::ADC, Operand::Absolute(addr)) => {
-                vec![0x6d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x6d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::ROR, Operand::Absolute(addr)) => {
-                vec![0x6e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x6e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
-            (Opcode::BVS, Operand::Relative(val)) => vec![0x70, val],
-            (Opcode::ADC, Operand::IndirectYIndexed(val)) => vec![0x71, val],
-            (Opcode::ADC, Operand::ZeroPageX(val)) => vec![0x75, val],
-            (Opcode::ROR, Operand::ZeroPageX(val)) => vec![0x76, val],
-            (Opcode::SEI, Operand::Implied) => vec![0x78],
+            (Opcode::BVS, Operand::Relative(val)) => ByteByByte::two(0x70, val),
+            (Opcode::ADC, Operand::IndirectYIndexed(val)) => ByteByByte::two(0x71, val),
+            (Opcode::ADC, Operand::ZeroPageX(val)) => ByteByByte::two(0x75, val),
+            (Opcode::ROR, Operand::ZeroPageX(val)) => ByteByByte::two(0x76, val),
+            (Opcode::SEI, Operand::Implied) => ByteByByte::one(0x78),
             (Opcode::ADC, Operand::AbsoluteY(addr)) => {
-                vec![0x79, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x79, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::ADC, Operand::AbsoluteX(addr)) => {
-                vec![0x7d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x7d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::ROR, Operand::AbsoluteX(addr)) => {
-                vec![0x7e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x7e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
-            (Opcode::STA, Operand::XIndexedIndirect(val)) => vec![0x81, val],
-            (Opcode::STY, Operand::ZeroPage(val)) => vec![0x84, val],
-            (Opcode::STA, Operand::ZeroPage(val)) => vec![0x85, val],
-            (Opcode::STX, Operand::ZeroPage(val)) => vec![0x86, val],
-            (Opcode::DEY, Operand::Implied) => vec![0x88],
-            (Opcode::TXA, Operand::Implied) => vec![0x8a],
+            (Opcode::STA, Operand::XIndexedIndirect(val)) => ByteByByte::two(0x81, val),
+            (Opcode::STY, Operand::ZeroPage(val)) => ByteByByte::two(0x84, val),
+            (Opcode::STA, Operand::ZeroPage(val)) => ByteByByte::two(0x85, val),
+            (Opcode::STX, Operand::ZeroPage(val)) => ByteByByte::two(0x86, val),
+            (Opcode::DEY, Operand::Implied) => ByteByByte::one(0x88),
+            (Opcode::TXA, Operand::Implied) => ByteByByte::one(0x8a),
             (Opcode::STY, Operand::Absolute(addr)) => {
-                vec![0x8c, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x8c, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
             (Opcode::STA, Operand::Absolute(addr)) => {
-                vec![0x8d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x8d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::STX, Operand::Absolute(addr)) => {
-                vec![0x8e, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x8e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
-            (Opcode::BCC, Operand::Relative(val)) => vec![0x90, val],
-            (Opcode::STA, Operand::IndirectYIndexed(val)) => vec![0x91, val],
-            (Opcode::STY, Operand::ZeroPageX(val)) => vec![0x94, val],
-            (Opcode::STA, Operand::ZeroPageX(val)) => vec![0x95, val],
-            (Opcode::STX, Operand::ZeroPageY(val)) => vec![0x96, val],
-            (Opcode::TYA, Operand::Implied) => vec![0x98],
+            (Opcode::BCC, Operand::Relative(val)) => ByteByByte::two(0x90, val),
+            (Opcode::STA, Operand::IndirectYIndexed(val)) => ByteByByte::two(0x91, val),
+            (Opcode::STY, Operand::ZeroPageX(val)) => ByteByByte::two(0x94, val),
+            (Opcode::STA, Operand::ZeroPageX(val)) => ByteByByte::two(0x95, val),
+            (Opcode::STX, Operand::ZeroPageY(val)) => ByteByByte::two(0x96, val),
+            (Opcode::TYA, Operand::Implied) => ByteByByte::one(0x98),
             (Opcode::STA, Operand::AbsoluteY(addr)) => {
-                vec![0x99, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x99, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
-            (Opcode::TXS, Operand::Implied) => vec![0x9a],
+            (Opcode::TXS, Operand::Implied) => ByteByByte::one(0x9a),
             (Opcode::STA, Operand::AbsoluteX(addr)) => {
-                vec![0x9d, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0x9d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
-            (Opcode::LDY, Operand::Immediate(val)) => vec![0xa0, val],
-            (Opcode::LDA, Operand::XIndexedIndirect(val)) => vec![0xa1, val],
-            (Opcode::LDX, Operand::Immediate(val)) => vec![0xa2, val],
-            (Opcode::LDY, Operand::ZeroPage(val)) => vec![0xa4, val],
-            (Opcode::LDA, Operand::ZeroPage(val)) => vec![0xa5, val],
-            (Opcode::LDX, Operand::ZeroPage(val)) => vec![0xa6, val],
-            (Opcode::TAY, Operand::Implied) => vec![0xa8],
-            (Opcode::LDA, Operand::Immediate(val)) => vec![0xa9, val],
-            (Opcode::TAX, Operand::Implied) => vec![0xaa],
+            (Opcode::LDY, Operand::Immediate(val)) => ByteByByte::two(0xa0, val),
+            (Opcode::LDA, Operand::XIndexedIndirect(val)) => ByteByByte::two(0xa1, val),
+            (Opcode::LDX, Operand::Immediate(val)) => ByteByByte::two(0xa2, val),
+            (Opcode::LDY, Operand::ZeroPage(val)) => ByteByByte::two(0xa4, val),
+            (Opcode::LDA, Operand::ZeroPage(val)) => ByteByByte::two(0xa5, val),
+            (Opcode::LDX, Operand::ZeroPage(val)) => ByteByByte::two(0xa6, val),
+            (Opcode::TAY, Operand::Implied) => ByteByByte::one(0xa8),
+            (Opcode::LDA, Operand::Immediate(val)) => ByteByByte::two(0xa9, val),
+            (Opcode::TAX, Operand::Implied) => ByteByByte::one(0xaa),
             (Opcode::LDY, Operand::Absolute(addr)) => {
-                vec![0xac, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0xac, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::LDA, Operand::Absolute(addr)) => {
-                vec![0xad, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0xad, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::LDX, Operand::Absolute(addr)) => {
-                vec![0xae, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0xae, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
-            (Opcode::BCS, Operand::Relative(val)) => vec![0xb0, val],
-            (Opcode::LDA, Operand::IndirectYIndexed(val)) => vec![0xb1, val],
-            (Opcode::LDY, Operand::ZeroPageX(val)) => vec![0xb4, val],
-            (Opcode::LDA, Operand::ZeroPageX(val)) => vec![0xb5, val],
-            (Opcode::LDX, Operand::ZeroPageY(val)) => vec![0xb6, val],
-            (Opcode::CLV, Operand::Implied) => vec![0xb8],
+            (Opcode::BCS, Operand::Relative(val)) => ByteByByte::two(0xb0, val),
+            (Opcode::LDA, Operand::IndirectYIndexed(val)) => ByteByByte::two(0xb1, val),
+            (Opcode::LDY, Operand::ZeroPageX(val)) => ByteByByte::two(0xb4, val),
+            (Opcode::LDA, Operand::ZeroPageX(val)) => ByteByByte::two(0xb5, val),
+            (Opcode::LDX, Operand::ZeroPageY(val)) => ByteByByte::two(0xb6, val),
+            (Opcode::CLV, Operand::Implied) => ByteByByte::one(0xb8),
             (Opcode::LDA, Operand::AbsoluteY(addr)) => {
-                vec![0xb9, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0xb9, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
-            (Opcode::TSX, Operand::Implied) => vec![0xba],
+            (Opcode::TSX, Operand::Implied) => ByteByByte::one(0xba),
             (Opcode::LDY, Operand::AbsoluteX(addr)) => {
-                vec![0xbc, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0xbc, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::LDA, Operand::AbsoluteX(addr)) => {
-                vec![0xbd, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0xbd, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::LDX, Operand::AbsoluteY(addr)) => {
-                vec![0xbe, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0xbe, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
-            (Opcode::CPY, Operand::Immediate(val)) => vec![0xc0, val],
-            (Opcode::CMP, Operand::XIndexedIndirect(val)) => vec![0xc1, val],
-            (Opcode::CPY, Operand::ZeroPage(val)) => vec![0xc4, val],
-            (Opcode::CMP, Operand::ZeroPage(val)) => vec![0xc5, val],
-            (Opcode::DEC, Operand::ZeroPage(val)) => vec![0xc6, val],
-            (Opcode::INY, Operand::Implied) => vec![0xc8],
-            (Opcode::CMP, Operand::Immediate(val)) => vec![0xc9, val],
-            (Opcode::DEX, Operand::Implied) => vec![0xca],
+            (Opcode::CPY, Operand::Immediate(val)) => ByteByByte::two(0xc0, val),
+            (Opcode::CMP, Operand::XIndexedIndirect(val)) => ByteByByte::two(0xc1, val),
+            (Opcode::CPY, Operand::ZeroPage(val)) => ByteByByte::two(0xc4, val),
+            (Opcode::CMP, Operand::ZeroPage(val)) => ByteByByte::two(0xc5, val),
+            (Opcode::DEC, Operand::ZeroPage(val)) => ByteByByte::two(0xc6, val),
+            (Opcode::INY, Operand::Implied) => ByteByByte::one(0xc8),
+            (Opcode::CMP, Operand::Immediate(val)) => ByteByByte::two(0xc9, val),
+            (Opcode::DEX, Operand::Implied) => ByteByByte::one(0xca),
             (Opcode::CPY, Operand::Absolute(addr)) => {
-                vec![0xcc, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0xcc, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::CMP, Operand::Absolute(addr)) => {
-                vec![0xcd, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0xcd, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::DEC, Operand::Absolute(addr)) => {
-                vec![0xce, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0xce, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
-            (Opcode::BNE, Operand::Relative(val)) => vec![0xd0, val],
-            (Opcode::CMP, Operand::IndirectYIndexed(val)) => vec![0xd1, val],
-            (Opcode::CMP, Operand::ZeroPageX(val)) => vec![0xd5, val],
-            (Opcode::DEC, Operand::ZeroPageX(val)) => vec![0xd6, val],
-            (Opcode::CLD, Operand::Implied) => vec![0xd8],
+            (Opcode::BNE, Operand::Relative(val)) => ByteByByte::two(0xd0, val),
+            (Opcode::CMP, Operand::IndirectYIndexed(val)) => ByteByByte::two(0xd1, val),
+            (Opcode::CMP, Operand::ZeroPageX(val)) => ByteByByte::two(0xd5, val),
+            (Opcode::DEC, Operand::ZeroPageX(val)) => ByteByByte::two(0xd6, val),
+            (Opcode::CLD, Operand::Implied) => ByteByByte::one(0xd8),
             (Opcode::CMP, Operand::AbsoluteY(addr)) => {
-                vec![0xd9, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0xd9, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::CMP, Operand::AbsoluteX(addr)) => {
-                vec![0xdd, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0xdd, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::DEC, Operand::AbsoluteX(addr)) => {
-                vec![0xde, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0xde, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
-            (Opcode::CPX, Operand::Immediate(val)) => vec![0xe0, val],
-            (Opcode::SBC, Operand::XIndexedIndirect(addr)) => vec![0xe1, addr],
-            (Opcode::CPX, Operand::ZeroPage(val)) => vec![0xe4, val],
-            (Opcode::SBC, Operand::ZeroPage(val)) => vec![0xe5, val],
-            (Opcode::INC, Operand::ZeroPage(val)) => vec![0xe6, val],
-            (Opcode::INX, Operand::Implied) => vec![0xe8],
-            (Opcode::SBC, Operand::Immediate(val)) => vec![0xe9, val],
-            (Opcode::NOP, Operand::Implied) => vec![0xea],
+            (Opcode::CPX, Operand::Immediate(val)) => ByteByByte::two(0xe0, val),
+            (Opcode::SBC, Operand::XIndexedIndirect(addr)) => ByteByByte::two(0xe1, addr),
+            (Opcode::CPX, Operand::ZeroPage(val)) => ByteByByte::two(0xe4, val),
+            (Opcode::SBC, Operand::ZeroPage(val)) => ByteByByte::two(0xe5, val),
+            (Opcode::INC, Operand::ZeroPage(val)) => ByteByByte::two(0xe6, val),
+            (Opcode::INX, Operand::Implied) => ByteByByte::one(0xe8),
+            (Opcode::SBC, Operand::Immediate(val)) => ByteByByte::two(0xe9, val),
+            (Opcode::NOP, Operand::Implied) => ByteByByte::one(0xea),
             (Opcode::CPX, Operand::Absolute(addr)) => {
-                vec![0xec, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0xec, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::SBC, Operand::Absolute(addr)) => {
-                vec![0xed, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0xed, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::INC, Operand::Absolute(addr)) => {
-                vec![0xee, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0xee, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
-            (Opcode::BEQ, Operand::Relative(val)) => vec![0xf0, val],
-            (Opcode::SBC, Operand::IndirectYIndexed(val)) => vec![0xf1, val],
-            (Opcode::SBC, Operand::ZeroPageX(val)) => vec![0xf5, val],
-            (Opcode::INC, Operand::ZeroPageX(val)) => vec![0xf6, val],
-            (Opcode::SED, Operand::Implied) => vec![0xf8],
+            (Opcode::BEQ, Operand::Relative(val)) => ByteByByte::two(0xf0, val),
+            (Opcode::SBC, Operand::IndirectYIndexed(val)) => ByteByByte::two(0xf1, val),
+            (Opcode::SBC, Operand::ZeroPageX(val)) => ByteByByte::two(0xf5, val),
+            (Opcode::INC, Operand::ZeroPageX(val)) => ByteByByte::two(0xf6, val),
+            (Opcode::SED, Operand::Implied) => ByteByByte::one(0xf8),
             (Opcode::SBC, Operand::AbsoluteY(addr)) => {
-                vec![0xf9, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0xf9, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::SBC, Operand::AbsoluteX(addr)) => {
-                vec![0xfd, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0xfd, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::INC, Operand::AbsoluteX(addr)) => {
-                vec![0xfe, addr.to_le_bytes()[0], addr.to_le_bytes()[1]]
+                ByteByByte::three(0xfe, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (_, _) => panic!(),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,14 +409,14 @@ impl Decoder<N6502> for InstDecoder {
     }
 }
 
-pub struct ByteByByte {
+pub struct Bytes {
     b1: u8,
     b2: u8,
     b3: u8,
     num: usize,
 }
 
-impl ByteByByte {
+impl Bytes {
     fn one(b1: u8) -> Self {
         Self {
             b1,
@@ -440,7 +440,7 @@ impl ByteByByte {
     }
 }
 
-impl Iterator for ByteByByte {
+impl Iterator for Bytes {
     type Item = u8;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -456,269 +456,269 @@ impl Iterator for ByteByByte {
 }
 
 impl Instruction {
-    pub fn decode(&self) -> ByteByByte {
+    pub fn decode(&self) -> Bytes {
         match (self.opcode, self.operand) {
-            (Opcode::BRK, Operand::Implied) => ByteByByte::one(0x00),
-            (Opcode::ORA, Operand::XIndexedIndirect(val)) => ByteByByte::two(0x01, val),
-            (Opcode::ORA, Operand::ZeroPage(val)) => ByteByByte::two(0x05, val),
-            (Opcode::ASL, Operand::ZeroPage(val)) => ByteByByte::two(0x06, val),
-            (Opcode::PHP, Operand::Implied) => ByteByByte::one(0x08),
-            (Opcode::ORA, Operand::Immediate(val)) => ByteByByte::two(0x09, val),
-            (Opcode::ASL, Operand::Accumulator) => ByteByByte::one(0x0a),
+            (Opcode::BRK, Operand::Implied) => Bytes::one(0x00),
+            (Opcode::ORA, Operand::XIndexedIndirect(val)) => Bytes::two(0x01, val),
+            (Opcode::ORA, Operand::ZeroPage(val)) => Bytes::two(0x05, val),
+            (Opcode::ASL, Operand::ZeroPage(val)) => Bytes::two(0x06, val),
+            (Opcode::PHP, Operand::Implied) => Bytes::one(0x08),
+            (Opcode::ORA, Operand::Immediate(val)) => Bytes::two(0x09, val),
+            (Opcode::ASL, Operand::Accumulator) => Bytes::one(0x0a),
             (Opcode::ORA, Operand::Absolute(addr)) => {
-                ByteByByte::three(0x0d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x0d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::ASL, Operand::Absolute(addr)) => {
-                ByteByByte::three(0x0e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x0e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
-            (Opcode::BPL, Operand::Relative(val)) => ByteByByte::two(0x10, val),
-            (Opcode::ORA, Operand::IndirectYIndexed(val)) => ByteByByte::two(0x11, val),
-            (Opcode::ORA, Operand::ZeroPageX(val)) => ByteByByte::two(0x15, val),
-            (Opcode::ASL, Operand::ZeroPageX(val)) => ByteByByte::two(0x16, val),
-            (Opcode::CLC, Operand::Implied) => ByteByByte::one(0x18),
+            (Opcode::BPL, Operand::Relative(val)) => Bytes::two(0x10, val),
+            (Opcode::ORA, Operand::IndirectYIndexed(val)) => Bytes::two(0x11, val),
+            (Opcode::ORA, Operand::ZeroPageX(val)) => Bytes::two(0x15, val),
+            (Opcode::ASL, Operand::ZeroPageX(val)) => Bytes::two(0x16, val),
+            (Opcode::CLC, Operand::Implied) => Bytes::one(0x18),
             (Opcode::ORA, Operand::AbsoluteY(addr)) => {
-                ByteByByte::three(0x19, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x19, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::ORA, Operand::AbsoluteX(addr)) => {
-                ByteByByte::three(0x1d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x1d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::ASL, Operand::AbsoluteX(addr)) => {
-                ByteByByte::three(0x1e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x1e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
             (Opcode::JSR, Operand::Absolute(addr)) => {
-                ByteByByte::three(0x20, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x20, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
-            (Opcode::AND, Operand::XIndexedIndirect(val)) => ByteByByte::two(0x21, val),
-            (Opcode::BIT, Operand::ZeroPage(val)) => ByteByByte::two(0x24, val),
-            (Opcode::AND, Operand::ZeroPage(val)) => ByteByByte::two(0x25, val),
-            (Opcode::ROL, Operand::ZeroPage(val)) => ByteByByte::two(0x26, val),
-            (Opcode::PLP, Operand::Implied) => ByteByByte::one(0x28),
-            (Opcode::AND, Operand::Immediate(val)) => ByteByByte::two(0x29, val),
-            (Opcode::ROL, Operand::Accumulator) => ByteByByte::one(0x2a),
+            (Opcode::AND, Operand::XIndexedIndirect(val)) => Bytes::two(0x21, val),
+            (Opcode::BIT, Operand::ZeroPage(val)) => Bytes::two(0x24, val),
+            (Opcode::AND, Operand::ZeroPage(val)) => Bytes::two(0x25, val),
+            (Opcode::ROL, Operand::ZeroPage(val)) => Bytes::two(0x26, val),
+            (Opcode::PLP, Operand::Implied) => Bytes::one(0x28),
+            (Opcode::AND, Operand::Immediate(val)) => Bytes::two(0x29, val),
+            (Opcode::ROL, Operand::Accumulator) => Bytes::one(0x2a),
             (Opcode::BIT, Operand::Absolute(addr)) => {
-                ByteByByte::three(0x2c, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x2c, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::AND, Operand::Absolute(addr)) => {
-                ByteByByte::three(0x2d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x2d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
             (Opcode::ROL, Operand::Absolute(addr)) => {
-                ByteByByte::three(0x2e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x2e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
-            (Opcode::BMI, Operand::Relative(val)) => ByteByByte::two(0x30, val),
-            (Opcode::AND, Operand::IndirectYIndexed(val)) => ByteByByte::two(0x31, val),
-            (Opcode::AND, Operand::ZeroPageX(val)) => ByteByByte::two(0x35, val),
-            (Opcode::ROL, Operand::ZeroPageX(val)) => ByteByByte::two(0x36, val),
-            (Opcode::SEC, Operand::Implied) => ByteByByte::one(0x38),
+            (Opcode::BMI, Operand::Relative(val)) => Bytes::two(0x30, val),
+            (Opcode::AND, Operand::IndirectYIndexed(val)) => Bytes::two(0x31, val),
+            (Opcode::AND, Operand::ZeroPageX(val)) => Bytes::two(0x35, val),
+            (Opcode::ROL, Operand::ZeroPageX(val)) => Bytes::two(0x36, val),
+            (Opcode::SEC, Operand::Implied) => Bytes::one(0x38),
             (Opcode::AND, Operand::AbsoluteY(addr)) => {
-                ByteByByte::three(0x39, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x39, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::AND, Operand::AbsoluteX(addr)) => {
-                ByteByByte::three(0x3d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x3d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::ROL, Operand::AbsoluteX(addr)) => {
-                ByteByByte::three(0x3e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x3e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
-            (Opcode::RTI, Operand::Implied) => ByteByByte::one(0x40),
-            (Opcode::EOR, Operand::XIndexedIndirect(val)) => ByteByByte::two(0x41, val),
-            (Opcode::EOR, Operand::ZeroPage(val)) => ByteByByte::two(0x45, val),
-            (Opcode::LSR, Operand::ZeroPage(val)) => ByteByByte::two(0x46, val),
-            (Opcode::PHA, Operand::Implied) => ByteByByte::one(0x48),
-            (Opcode::EOR, Operand::Immediate(val)) => ByteByByte::two(0x49, val),
-            (Opcode::LSR, Operand::Accumulator) => ByteByByte::one(0x4a),
+            (Opcode::RTI, Operand::Implied) => Bytes::one(0x40),
+            (Opcode::EOR, Operand::XIndexedIndirect(val)) => Bytes::two(0x41, val),
+            (Opcode::EOR, Operand::ZeroPage(val)) => Bytes::two(0x45, val),
+            (Opcode::LSR, Operand::ZeroPage(val)) => Bytes::two(0x46, val),
+            (Opcode::PHA, Operand::Implied) => Bytes::one(0x48),
+            (Opcode::EOR, Operand::Immediate(val)) => Bytes::two(0x49, val),
+            (Opcode::LSR, Operand::Accumulator) => Bytes::one(0x4a),
             (Opcode::JMP, Operand::Absolute(addr)) => {
-                ByteByByte::three(0x4c, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x4c, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::EOR, Operand::Absolute(addr)) => {
-                ByteByByte::three(0x4d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x4d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::LSR, Operand::Absolute(addr)) => {
-                ByteByByte::three(0x4e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x4e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
-            (Opcode::BVC, Operand::Relative(val)) => ByteByByte::two(0x50, val),
-            (Opcode::EOR, Operand::IndirectYIndexed(val)) => ByteByByte::two(0x51, val),
-            (Opcode::EOR, Operand::ZeroPageX(val)) => ByteByByte::two(0x55, val),
-            (Opcode::LSR, Operand::ZeroPageX(val)) => ByteByByte::two(0x56, val),
-            (Opcode::CLI, Operand::Implied) => ByteByByte::one(0x58),
+            (Opcode::BVC, Operand::Relative(val)) => Bytes::two(0x50, val),
+            (Opcode::EOR, Operand::IndirectYIndexed(val)) => Bytes::two(0x51, val),
+            (Opcode::EOR, Operand::ZeroPageX(val)) => Bytes::two(0x55, val),
+            (Opcode::LSR, Operand::ZeroPageX(val)) => Bytes::two(0x56, val),
+            (Opcode::CLI, Operand::Implied) => Bytes::one(0x58),
             (Opcode::EOR, Operand::AbsoluteY(addr)) => {
-                ByteByByte::three(0x59, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x59, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::EOR, Operand::AbsoluteX(addr)) => {
-                ByteByByte::three(0x5d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x5d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::LSR, Operand::AbsoluteX(addr)) => {
-                ByteByByte::three(0x5e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x5e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
-            (Opcode::RTS, Operand::Implied) => ByteByByte::one(0x60),
-            (Opcode::ADC, Operand::XIndexedIndirect(val)) => ByteByByte::two(0x61, val),
-            (Opcode::ADC, Operand::ZeroPage(val)) => ByteByByte::two(0x65, val),
-            (Opcode::ROR, Operand::ZeroPage(val)) => ByteByByte::two(0x66, val),
-            (Opcode::PLA, Operand::Implied) => ByteByByte::one(0x68),
-            (Opcode::ADC, Operand::Immediate(val)) => ByteByByte::two(0x69, val),
-            (Opcode::ROR, Operand::Accumulator) => ByteByByte::one(0x6a),
+            (Opcode::RTS, Operand::Implied) => Bytes::one(0x60),
+            (Opcode::ADC, Operand::XIndexedIndirect(val)) => Bytes::two(0x61, val),
+            (Opcode::ADC, Operand::ZeroPage(val)) => Bytes::two(0x65, val),
+            (Opcode::ROR, Operand::ZeroPage(val)) => Bytes::two(0x66, val),
+            (Opcode::PLA, Operand::Implied) => Bytes::one(0x68),
+            (Opcode::ADC, Operand::Immediate(val)) => Bytes::two(0x69, val),
+            (Opcode::ROR, Operand::Accumulator) => Bytes::one(0x6a),
             (Opcode::JMP, Operand::Indirect(addr)) => {
-                ByteByByte::three(0x6c, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x6c, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::ADC, Operand::Absolute(addr)) => {
-                ByteByByte::three(0x6d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x6d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::ROR, Operand::Absolute(addr)) => {
-                ByteByByte::three(0x6e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x6e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
-            (Opcode::BVS, Operand::Relative(val)) => ByteByByte::two(0x70, val),
-            (Opcode::ADC, Operand::IndirectYIndexed(val)) => ByteByByte::two(0x71, val),
-            (Opcode::ADC, Operand::ZeroPageX(val)) => ByteByByte::two(0x75, val),
-            (Opcode::ROR, Operand::ZeroPageX(val)) => ByteByByte::two(0x76, val),
-            (Opcode::SEI, Operand::Implied) => ByteByByte::one(0x78),
+            (Opcode::BVS, Operand::Relative(val)) => Bytes::two(0x70, val),
+            (Opcode::ADC, Operand::IndirectYIndexed(val)) => Bytes::two(0x71, val),
+            (Opcode::ADC, Operand::ZeroPageX(val)) => Bytes::two(0x75, val),
+            (Opcode::ROR, Operand::ZeroPageX(val)) => Bytes::two(0x76, val),
+            (Opcode::SEI, Operand::Implied) => Bytes::one(0x78),
             (Opcode::ADC, Operand::AbsoluteY(addr)) => {
-                ByteByByte::three(0x79, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x79, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::ADC, Operand::AbsoluteX(addr)) => {
-                ByteByByte::three(0x7d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x7d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::ROR, Operand::AbsoluteX(addr)) => {
-                ByteByByte::three(0x7e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x7e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
-            (Opcode::STA, Operand::XIndexedIndirect(val)) => ByteByByte::two(0x81, val),
-            (Opcode::STY, Operand::ZeroPage(val)) => ByteByByte::two(0x84, val),
-            (Opcode::STA, Operand::ZeroPage(val)) => ByteByByte::two(0x85, val),
-            (Opcode::STX, Operand::ZeroPage(val)) => ByteByByte::two(0x86, val),
-            (Opcode::DEY, Operand::Implied) => ByteByByte::one(0x88),
-            (Opcode::TXA, Operand::Implied) => ByteByByte::one(0x8a),
+            (Opcode::STA, Operand::XIndexedIndirect(val)) => Bytes::two(0x81, val),
+            (Opcode::STY, Operand::ZeroPage(val)) => Bytes::two(0x84, val),
+            (Opcode::STA, Operand::ZeroPage(val)) => Bytes::two(0x85, val),
+            (Opcode::STX, Operand::ZeroPage(val)) => Bytes::two(0x86, val),
+            (Opcode::DEY, Operand::Implied) => Bytes::one(0x88),
+            (Opcode::TXA, Operand::Implied) => Bytes::one(0x8a),
             (Opcode::STY, Operand::Absolute(addr)) => {
-                ByteByByte::three(0x8c, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x8c, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
             (Opcode::STA, Operand::Absolute(addr)) => {
-                ByteByByte::three(0x8d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x8d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::STX, Operand::Absolute(addr)) => {
-                ByteByByte::three(0x8e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x8e, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
-            (Opcode::BCC, Operand::Relative(val)) => ByteByByte::two(0x90, val),
-            (Opcode::STA, Operand::IndirectYIndexed(val)) => ByteByByte::two(0x91, val),
-            (Opcode::STY, Operand::ZeroPageX(val)) => ByteByByte::two(0x94, val),
-            (Opcode::STA, Operand::ZeroPageX(val)) => ByteByByte::two(0x95, val),
-            (Opcode::STX, Operand::ZeroPageY(val)) => ByteByByte::two(0x96, val),
-            (Opcode::TYA, Operand::Implied) => ByteByByte::one(0x98),
+            (Opcode::BCC, Operand::Relative(val)) => Bytes::two(0x90, val),
+            (Opcode::STA, Operand::IndirectYIndexed(val)) => Bytes::two(0x91, val),
+            (Opcode::STY, Operand::ZeroPageX(val)) => Bytes::two(0x94, val),
+            (Opcode::STA, Operand::ZeroPageX(val)) => Bytes::two(0x95, val),
+            (Opcode::STX, Operand::ZeroPageY(val)) => Bytes::two(0x96, val),
+            (Opcode::TYA, Operand::Implied) => Bytes::one(0x98),
             (Opcode::STA, Operand::AbsoluteY(addr)) => {
-                ByteByByte::three(0x99, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x99, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
-            (Opcode::TXS, Operand::Implied) => ByteByByte::one(0x9a),
+            (Opcode::TXS, Operand::Implied) => Bytes::one(0x9a),
             (Opcode::STA, Operand::AbsoluteX(addr)) => {
-                ByteByByte::three(0x9d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0x9d, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
-            (Opcode::LDY, Operand::Immediate(val)) => ByteByByte::two(0xa0, val),
-            (Opcode::LDA, Operand::XIndexedIndirect(val)) => ByteByByte::two(0xa1, val),
-            (Opcode::LDX, Operand::Immediate(val)) => ByteByByte::two(0xa2, val),
-            (Opcode::LDY, Operand::ZeroPage(val)) => ByteByByte::two(0xa4, val),
-            (Opcode::LDA, Operand::ZeroPage(val)) => ByteByByte::two(0xa5, val),
-            (Opcode::LDX, Operand::ZeroPage(val)) => ByteByByte::two(0xa6, val),
-            (Opcode::TAY, Operand::Implied) => ByteByByte::one(0xa8),
-            (Opcode::LDA, Operand::Immediate(val)) => ByteByByte::two(0xa9, val),
-            (Opcode::TAX, Operand::Implied) => ByteByByte::one(0xaa),
+            (Opcode::LDY, Operand::Immediate(val)) => Bytes::two(0xa0, val),
+            (Opcode::LDA, Operand::XIndexedIndirect(val)) => Bytes::two(0xa1, val),
+            (Opcode::LDX, Operand::Immediate(val)) => Bytes::two(0xa2, val),
+            (Opcode::LDY, Operand::ZeroPage(val)) => Bytes::two(0xa4, val),
+            (Opcode::LDA, Operand::ZeroPage(val)) => Bytes::two(0xa5, val),
+            (Opcode::LDX, Operand::ZeroPage(val)) => Bytes::two(0xa6, val),
+            (Opcode::TAY, Operand::Implied) => Bytes::one(0xa8),
+            (Opcode::LDA, Operand::Immediate(val)) => Bytes::two(0xa9, val),
+            (Opcode::TAX, Operand::Implied) => Bytes::one(0xaa),
             (Opcode::LDY, Operand::Absolute(addr)) => {
-                ByteByByte::three(0xac, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0xac, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::LDA, Operand::Absolute(addr)) => {
-                ByteByByte::three(0xad, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0xad, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::LDX, Operand::Absolute(addr)) => {
-                ByteByByte::three(0xae, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0xae, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
-            (Opcode::BCS, Operand::Relative(val)) => ByteByByte::two(0xb0, val),
-            (Opcode::LDA, Operand::IndirectYIndexed(val)) => ByteByByte::two(0xb1, val),
-            (Opcode::LDY, Operand::ZeroPageX(val)) => ByteByByte::two(0xb4, val),
-            (Opcode::LDA, Operand::ZeroPageX(val)) => ByteByByte::two(0xb5, val),
-            (Opcode::LDX, Operand::ZeroPageY(val)) => ByteByByte::two(0xb6, val),
-            (Opcode::CLV, Operand::Implied) => ByteByByte::one(0xb8),
+            (Opcode::BCS, Operand::Relative(val)) => Bytes::two(0xb0, val),
+            (Opcode::LDA, Operand::IndirectYIndexed(val)) => Bytes::two(0xb1, val),
+            (Opcode::LDY, Operand::ZeroPageX(val)) => Bytes::two(0xb4, val),
+            (Opcode::LDA, Operand::ZeroPageX(val)) => Bytes::two(0xb5, val),
+            (Opcode::LDX, Operand::ZeroPageY(val)) => Bytes::two(0xb6, val),
+            (Opcode::CLV, Operand::Implied) => Bytes::one(0xb8),
             (Opcode::LDA, Operand::AbsoluteY(addr)) => {
-                ByteByByte::three(0xb9, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0xb9, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
-            (Opcode::TSX, Operand::Implied) => ByteByByte::one(0xba),
+            (Opcode::TSX, Operand::Implied) => Bytes::one(0xba),
             (Opcode::LDY, Operand::AbsoluteX(addr)) => {
-                ByteByByte::three(0xbc, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0xbc, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::LDA, Operand::AbsoluteX(addr)) => {
-                ByteByByte::three(0xbd, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0xbd, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::LDX, Operand::AbsoluteY(addr)) => {
-                ByteByByte::three(0xbe, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0xbe, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
-            (Opcode::CPY, Operand::Immediate(val)) => ByteByByte::two(0xc0, val),
-            (Opcode::CMP, Operand::XIndexedIndirect(val)) => ByteByByte::two(0xc1, val),
-            (Opcode::CPY, Operand::ZeroPage(val)) => ByteByByte::two(0xc4, val),
-            (Opcode::CMP, Operand::ZeroPage(val)) => ByteByByte::two(0xc5, val),
-            (Opcode::DEC, Operand::ZeroPage(val)) => ByteByByte::two(0xc6, val),
-            (Opcode::INY, Operand::Implied) => ByteByByte::one(0xc8),
-            (Opcode::CMP, Operand::Immediate(val)) => ByteByByte::two(0xc9, val),
-            (Opcode::DEX, Operand::Implied) => ByteByByte::one(0xca),
+            (Opcode::CPY, Operand::Immediate(val)) => Bytes::two(0xc0, val),
+            (Opcode::CMP, Operand::XIndexedIndirect(val)) => Bytes::two(0xc1, val),
+            (Opcode::CPY, Operand::ZeroPage(val)) => Bytes::two(0xc4, val),
+            (Opcode::CMP, Operand::ZeroPage(val)) => Bytes::two(0xc5, val),
+            (Opcode::DEC, Operand::ZeroPage(val)) => Bytes::two(0xc6, val),
+            (Opcode::INY, Operand::Implied) => Bytes::one(0xc8),
+            (Opcode::CMP, Operand::Immediate(val)) => Bytes::two(0xc9, val),
+            (Opcode::DEX, Operand::Implied) => Bytes::one(0xca),
             (Opcode::CPY, Operand::Absolute(addr)) => {
-                ByteByByte::three(0xcc, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0xcc, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::CMP, Operand::Absolute(addr)) => {
-                ByteByByte::three(0xcd, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0xcd, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::DEC, Operand::Absolute(addr)) => {
-                ByteByByte::three(0xce, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0xce, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
-            (Opcode::BNE, Operand::Relative(val)) => ByteByByte::two(0xd0, val),
-            (Opcode::CMP, Operand::IndirectYIndexed(val)) => ByteByByte::two(0xd1, val),
-            (Opcode::CMP, Operand::ZeroPageX(val)) => ByteByByte::two(0xd5, val),
-            (Opcode::DEC, Operand::ZeroPageX(val)) => ByteByByte::two(0xd6, val),
-            (Opcode::CLD, Operand::Implied) => ByteByByte::one(0xd8),
+            (Opcode::BNE, Operand::Relative(val)) => Bytes::two(0xd0, val),
+            (Opcode::CMP, Operand::IndirectYIndexed(val)) => Bytes::two(0xd1, val),
+            (Opcode::CMP, Operand::ZeroPageX(val)) => Bytes::two(0xd5, val),
+            (Opcode::DEC, Operand::ZeroPageX(val)) => Bytes::two(0xd6, val),
+            (Opcode::CLD, Operand::Implied) => Bytes::one(0xd8),
             (Opcode::CMP, Operand::AbsoluteY(addr)) => {
-                ByteByByte::three(0xd9, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0xd9, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::CMP, Operand::AbsoluteX(addr)) => {
-                ByteByByte::three(0xdd, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0xdd, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::DEC, Operand::AbsoluteX(addr)) => {
-                ByteByByte::three(0xde, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0xde, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
-            (Opcode::CPX, Operand::Immediate(val)) => ByteByByte::two(0xe0, val),
-            (Opcode::SBC, Operand::XIndexedIndirect(addr)) => ByteByByte::two(0xe1, addr),
-            (Opcode::CPX, Operand::ZeroPage(val)) => ByteByByte::two(0xe4, val),
-            (Opcode::SBC, Operand::ZeroPage(val)) => ByteByByte::two(0xe5, val),
-            (Opcode::INC, Operand::ZeroPage(val)) => ByteByByte::two(0xe6, val),
-            (Opcode::INX, Operand::Implied) => ByteByByte::one(0xe8),
-            (Opcode::SBC, Operand::Immediate(val)) => ByteByByte::two(0xe9, val),
-            (Opcode::NOP, Operand::Implied) => ByteByByte::one(0xea),
+            (Opcode::CPX, Operand::Immediate(val)) => Bytes::two(0xe0, val),
+            (Opcode::SBC, Operand::XIndexedIndirect(addr)) => Bytes::two(0xe1, addr),
+            (Opcode::CPX, Operand::ZeroPage(val)) => Bytes::two(0xe4, val),
+            (Opcode::SBC, Operand::ZeroPage(val)) => Bytes::two(0xe5, val),
+            (Opcode::INC, Operand::ZeroPage(val)) => Bytes::two(0xe6, val),
+            (Opcode::INX, Operand::Implied) => Bytes::one(0xe8),
+            (Opcode::SBC, Operand::Immediate(val)) => Bytes::two(0xe9, val),
+            (Opcode::NOP, Operand::Implied) => Bytes::one(0xea),
             (Opcode::CPX, Operand::Absolute(addr)) => {
-                ByteByByte::three(0xec, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0xec, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::SBC, Operand::Absolute(addr)) => {
-                ByteByByte::three(0xed, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0xed, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::INC, Operand::Absolute(addr)) => {
-                ByteByByte::three(0xee, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0xee, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
 
-            (Opcode::BEQ, Operand::Relative(val)) => ByteByByte::two(0xf0, val),
-            (Opcode::SBC, Operand::IndirectYIndexed(val)) => ByteByByte::two(0xf1, val),
-            (Opcode::SBC, Operand::ZeroPageX(val)) => ByteByByte::two(0xf5, val),
-            (Opcode::INC, Operand::ZeroPageX(val)) => ByteByByte::two(0xf6, val),
-            (Opcode::SED, Operand::Implied) => ByteByByte::one(0xf8),
+            (Opcode::BEQ, Operand::Relative(val)) => Bytes::two(0xf0, val),
+            (Opcode::SBC, Operand::IndirectYIndexed(val)) => Bytes::two(0xf1, val),
+            (Opcode::SBC, Operand::ZeroPageX(val)) => Bytes::two(0xf5, val),
+            (Opcode::INC, Operand::ZeroPageX(val)) => Bytes::two(0xf6, val),
+            (Opcode::SED, Operand::Implied) => Bytes::one(0xf8),
             (Opcode::SBC, Operand::AbsoluteY(addr)) => {
-                ByteByByte::three(0xf9, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0xf9, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::SBC, Operand::AbsoluteX(addr)) => {
-                ByteByByte::three(0xfd, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0xfd, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (Opcode::INC, Operand::AbsoluteX(addr)) => {
-                ByteByByte::three(0xfe, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
+                Bytes::three(0xfe, addr.to_le_bytes()[0], addr.to_le_bytes()[1])
             }
             (_, _) => panic!(),
         }


### PR DESCRIPTION
We could use an `encode` method on an `Instruction` to yield the instruction's encoding.

I've essentially copy-pasted the function I'm using into the yaxpeax-6502 codebase. But it doesn't build because `macro vec not found in this scope`? Why is this happening? Maybe it's something to do with no-std. I've never seen this error before. If I can't use `Vec<u8>` for this then I'll probably do a custom type that `impl`s `Iterator<u8>`. But this decision needs to be considered carefully and with regard for what other yaxpeax backends might need.

Still other things to consider:

- [ ] testing decoder and encoder against each other
- [ ] Some kind of trait that's usable on other yaxpeax backends as well; this probably needs involvement from the `yaxpeax-arch` project