### PR TITLE
Encoder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -723,7 +723,7 @@ impl Instruction {
             (Opcode::INC, Operand::AbsoluteX(addr)) => {
                 Ok(Bytes::three(0xfe, addr.to_le_bytes()[0], addr.to_le_bytes()[1]))
             }
-            (_, _) => panic!(),
+            (_, _) => Err(EncodeError::EncodeError),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -459,7 +459,7 @@ impl Iterator for Bytes {
 }
 
 impl Instruction {
-    pub fn decode(&self) -> Result<Bytes, EncodeError> {
+    pub fn encode(&self) -> Result<Bytes, EncodeError> {
         match (self.opcode, self.operand) {
             (Opcode::BRK, Operand::Implied) => Ok(Bytes::one(0x00)),
             (Opcode::ORA, Operand::XIndexedIndirect(val)) => Ok(Bytes::two(0x01, val)),


### PR DESCRIPTION
So on the encoder branch of omarandlorraine/yaxpeax-6502 we've got two commits that have not made it into your main branch:

- `8fcc2ee` return Err(EncodeError) instead of panicking
- `67175c7` rename decode to encode
